### PR TITLE
Try catch - instead using promises

### DIFF
--- a/src/components/DataLabelling.js
+++ b/src/components/DataLabelling.js
@@ -15,11 +15,17 @@ const DataLabelling = () => {
     getImage();
   }, [renderImage]);
 
-  const getImage = async () => {
+  const getImage = () => {
     const api = 'https://tyi19eoxij.execute-api.us-west-2.amazonaws.com/prod';
-    const response = await fetch(api);
-    const json = await response.json();
-    setResults(json);
+    fetch(api)
+      .then(response => response.json())
+      .then(data => {
+        console.log('Success:', data);
+        setResults(data);
+      })
+      .catch(error => {
+        console.error('Error:', error);
+      });
   };
 
   const renderResults = () => {

--- a/src/components/Form/ImageForm.js
+++ b/src/components/Form/ImageForm.js
@@ -9,25 +9,34 @@ const ImageForm = ({ code, id, setRenderImage }) => {
 
   const onSubmit = data => {
     // makes POST request from API, if passes form validation
-    updateImage(data);
-    // sets the state for the parent component to fetch and render a new image
-    setRenderImage(id);
-    // renders new form fields
-    renderedFields();
-    // resets the form fields
-    reset();
+    postImage(data);
   };
 
-  const updateImage = async data => {
+  const postImage = data => {
     const api = `https://tyi19eoxij.execute-api.us-west-2.amazonaws.com/prod/${id}`;
-    const response = await fetch(api, {
+    fetch(api, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
+    }).then(response => {
+      if (response.ok) {
+        console.log('Success: ', response);
+        getNewImage();
+      } else {
+        console.error('Error: ', response);
+      }
     });
-    return console.log(response.statusText);
+  };
+
+  const getNewImage = () => {
+    // sets the state for the parent component to fetch and render a new image
+    setRenderImage(id);
+    //renders new form fields
+    renderedFields();
+    //resets the form fields
+    reset();
   };
 
   const renderedFields = () => {


### PR DESCRIPTION
I initially was going to use try catch on the api calls, but used promises in two different implementations for post and get. 